### PR TITLE
docs: expand project docs and add community policies

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,14 @@
+# Code of Conduct
+
+We pledge to make participation in this project a harassment-free experience for everyone.
+
+## Our Standards
+- Be respectful and inclusive.
+- Accept constructive criticism with grace.
+- Show empathy toward other community members.
+
+## Enforcement
+Report unacceptable behavior to <security@example.com>. Project maintainers will review and respond appropriately.
+
+## Attribution
+Adapted from the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).

--- a/README.md
+++ b/README.md
@@ -122,8 +122,9 @@ mkdocs build
 ## Contributing
 
 1. Read the [Contributing Guide](docs/CONTRIBUTING.md)
-2. Check existing [Issues](https://github.com/hue/Dopemux-ChatRipperXX/issues)
-3. Follow the development process in [CLAUDE.md](CLAUDE.md)
+2. Review the [Code of Conduct](CODE_OF_CONDUCT.md)
+3. Check existing [Issues](https://github.com/hue/Dopemux-ChatRipperXX/issues)
+4. Follow the development process in [CLAUDE.md](CLAUDE.md)
 
 ## License
 
@@ -131,4 +132,4 @@ MIT License - see [LICENSE](LICENSE) for details.
 
 ## Security
 
-This tool handles sensitive personal data. Please review the [Security Documentation](docs/CR-XactXtract/PROJECT_DESIGN_FILES/SECURITY_THREAT_MODEL.md) and follow security best practices.
+This tool handles sensitive personal data. Please review the [Security Documentation](docs/CR-XactXtract/PROJECT_DESIGN_FILES/SECURITY_THREAT_MODEL.md), see [SECURITY.md](SECURITY.md) for vulnerability reporting, and follow security best practices.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,10 @@
+# Security Policy
+
+## Supported Versions
+We release security patches for the latest stable version of ChatX.
+
+## Reporting a Vulnerability
+Please email security@example.com with details. We will acknowledge receipt within 48 hours and provide a fix timeline.
+
+## Responsible Disclosure
+Do not publicly disclose vulnerabilities until we have released a patch and coordinated an announcement.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,0 +1,10 @@
+# FAQ
+
+### Why does ChatX run locally?
+To keep your saucy secrets on your own machine where they belong.
+
+### Can I add a new chat platform?
+Yes. Write an extractor plugin and tests, then submit a PR.
+
+### How do I report a bug?
+Open an issue with logs and reproduction steps.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,8 +1,8 @@
 # Architecture
 
 ## Context
-- CLI entrypoint, core modules, adapters (I/O, API), and persistence (if any).
-- Non‑Functional Requirements: performance, robustness, security, observability.
+- Privacy‑first CLI that ingests chat exports and runs an offline pipeline.
+- Non‑Functional Requirements: local processing only, predictable runtime, strong redaction guarantees, and observable behavior.
 
 ## Module Boundaries
 - **cli/** — argument parsing, commands
@@ -11,9 +11,15 @@
 - **tests/** — unit + integration tests
 
 ## Data & Flows (sketch)
-- Describe request/response, error flows, and where side effects occur.
+- **Extract → Transform → Redact → Enrich → Analyze**.
+- Extractors pull platform data into canonical JSON.
+- Transformers normalize fields and validate against schemas.
+- Redaction removes PII before any optional cloud work.
+- Enrichment augments messages with LLM‑generated metadata.
+- Analysis modules generate reports from enriched artifacts.
 
 ## Observability
-- Logging levels and structure, metrics (if any).
+- Structured JSON logs at INFO level by default, DEBUG for troubleshooting.
+- Hook points for metrics backends to track pipeline duration and message counts.
 
 > Update this file when boundaries or flows change. Record critical decisions in ADRs.

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,10 +3,10 @@
 **Last updated:** 2025-09-02 UTC
 
 ## Vision (1‑pager)
-- **Problem:** _Fill in succinctly:_ What pain does this CLI solve?
-- **Audience:** _Who uses it?_
-- **Non‑Goals:** _What this project will not do (for now)._
-- **Success Metrics:** _e.g., CLI task completes < 2s; test coverage ≥ 90%; zero critical defects per release._
+- **Problem:** Manual chat forensics is slow, inconsistent, and often leaks sensitive data.
+- **Audience:** Digital forensics investigators and privacy‑minded power users.
+- **Non‑Goals:** Real‑time surveillance, cloud‑first processing, or vendor‑locked features.
+- **Success Metrics:** Pipeline handles 100 messages in <2 s, test coverage ≥90%, zero P1 issues per release.
 
 ## MVP Scope
 - Link to tracked **User Stories** in GitHub Issues (Now/Next/Later).


### PR DESCRIPTION
## Summary
- detail vision and success metrics in project overview
- document core pipeline and observability notes
- add Code of Conduct, Security policy, and FAQ, linking from README

## Testing
- `ruff check .`
- `mypy src`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b678344024832698f21db3a5d4ea82