### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/utf8-check.yml
+++ b/.github/workflows/utf8-check.yml
@@ -5,6 +5,8 @@ on:
 
 jobs:
   utf8:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/hu3mann/ChatRipperXX_DOPEMUX/security/code-scanning/1](https://github.com/hu3mann/ChatRipperXX_DOPEMUX/security/code-scanning/1)

To fix the issue, add a `permissions` block at either the top level of the workflow (so it applies to all jobs unless overridden), or at the job level (within the `jobs.utf8` section). For this workflow, as there is only a single job, either location is appropriate; however, placing it at the job level is more precise, in case additional jobs are added in the future with different needs. Set `contents: read` to grant the minimum required permissions: the `actions/checkout` step needs to read repository contents, and the UTF-8 validation step runs a local script. Edit the `.github/workflows/utf8-check.yml` file, adding a `permissions: contents: read` block under the `jobs: utf8:` section (between lines 7 and 8).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
