### PR TITLE
docs: clarify diff vs XML workflow

### DIFF
--- a/.claude/commands/diff-proposal.md
+++ b/.claude/commands/diff-proposal.md
@@ -1,0 +1,6 @@
+Output a **unified diff (patch)** for the minimal set of changes to implement the approved plan.
+
+Rules:
+- Keep it surgical; do not include unrelated files.
+- Ensure the patch applies with: `git apply -p0 < patch.diff` from repo root.
+- After apply, run: `pytest -q`, `ruff check .`, `mypy --ignore-missing-imports .`; then update `/docs` & ADRs and proceed to PR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,10 @@ Status: Draft | Owner: <TBD> | Last Updated: 2025-09-02
 ## Purpose
 Make Claude Code produce **small, correct patches** that build and pass on the first run, while leveraging **Model Context Protocol (MCP)** servers for persistent memory, context injection, search, and integrations. This file is auto-loaded as project memory at session start; the `@…` imports above bring key specs into context without copy-pasting.
 
+## Editing policy
+- In Claude Code sessions (terminal): you may edit files directly or return a unified diff (we'll apply with `git apply`).
+- In web/chat sessions: return a Repo Prompt XML edits document (see `docs/repo-prompt-xml.md`) and we'll apply via Repo Prompt's Apply tab or MCP tool.
+
 ---
 
 ## 0) Session bootstrap (Claude, do this first)

--- a/docs/agent-workflows.md
+++ b/docs/agent-workflows.md
@@ -1,0 +1,22 @@
+# Agent Workflows (Claude Code + MCP)
+_Last updated: 2025-09-02 UTC_
+
+## Tools
+- Claude Code (CLI) and **Claude Context** (MCP) for semantic code search
+- **GitHub** MCP to create issues/PRs and read CI logs
+- **Repo Prompt** (MCP) for XML-based edits
+- `gh` (GitHub CLI) and **aicommits** for Conventional Commits
+
+## Loop
+1. **Explore** (no writes): read specific files and latest ADRs.
+2. **Plan** (`/project:plan-think` or “think hard”): small, testable steps.
+3. **Create issue** (GitHub MCP or `gh issue create`) using templates.
+4. **TDD**: `/project:tdd-start` (failing test) → `/project:tdd-implement` (make green + refactor).
+5. **Docs/ADR** updates.
+6. **Commit**: aicommits drafts a Conventional Commit.
+7. **PR**: `/project:pr-open` or `gh pr create`; CI runs tests/lint/types and docs-updated gate.
+8. **Merge**; docs auto-deploy to Pages.
+
+## Chat Sessions (XML apply)
+- **Web/chat outputs:** return a **Repo Prompt XML edits document** and apply via Repo Prompt’s **Apply** tab or its MCP tool.
+- **Claude Code sessions (terminal):** the agent may **edit files directly** or **emit a unified diff** (we’ll apply with `git apply`). After apply: run `pytest -q`, `ruff`, `mypy`; update `/docs` & ADRs; Conventional Commit; PR.

--- a/docs/repo-prompt-xml.md
+++ b/docs/repo-prompt-xml.md
@@ -1,0 +1,50 @@
+# Repo Prompt XML Apply — Project Standard
+_Last updated: 2025-09-02 UTC_
+
+This project standardizes on **Repo Prompt's XML-based apply format** for web/chat edits. Agents must produce an **XML edits document** that Repo Prompt can apply deterministically across many files.
+
+## Why XML apply?
+- Handles **large & multi-file** changes
+- **Parsable, idempotent**, previewable
+- Works with Claude Code via MCP and other models
+
+## How to use
+1. Load this repo in Repo Prompt (or connect via MCP).
+2. Ask the model to output **XML edits** (see skeleton below).
+3. Apply in Repo Prompt's **Apply** tab (or call its MCP tool).
+4. Run `pytest -q`, `ruff check .`, `mypy --ignore-missing-imports .`; update docs/ADRs; commit; PR.
+
+## XML skeleton (generic)
+```xml
+<edits>
+  <create path="path/to/new_file.py"><![CDATA[
+# new file content here
+]]></create>
+
+  <replace path="src/module/foo.py">
+    <find><![CDATA[
+def old_fn():
+    pass
+]]></find>
+    <with><![CDATA[
+def old_fn() -> None:
+    """Deprecated; use new_fn."""
+    raise NotImplementedError("Use new_fn")
+]]></with>
+  </replace>
+
+  <append path="tests/test_foo.py"><![CDATA[
+def test_hello():
+    assert True
+]]></append>
+
+  <delete path="obsolete/legacy.py" />
+</edits>
+```
+
+### Agent rules
+
+* Keep edits **minimal and surgical**; avoid wholesale rewrites.
+* Include just enough context in <find> to match unambiguously.
+* Use **CDATA** blocks for code; ensure XML is well-formed.
+* After apply, update `/docs` and ADRs in the same PR.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,8 @@ nav:
   - Architecture: architecture.md
   - ADRs:
       - ADR Index: adr/index.md
+  - Agent Workflows: agent-workflows.md
+  - Repo Prompt XML Apply: repo-prompt-xml.md
   - Additional Docs:
       - README: README.md
       - LLM Context: CR-XactXtract/llm-context.md


### PR DESCRIPTION
## Summary
- document diff vs XML edit policy in CLAUDE playbook
- add agent-workflows and repo-prompt-xml docs
- introduce diff-proposal command and link docs in MkDocs nav

## Testing
- `ruff check .`
- `mypy --ignore-missing-imports .` *(fails: missing annotations in tests)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b6c0736914832698f72df08393b1d6