### PR TITLE
test: ensure src path for tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,12 @@
 """Test configuration and fixtures."""
 
+import sys
 from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from chatx.schemas.message import CanonicalMessage, SourceRef
 from tests.fixtures import create_imessage_test_db, get_expected_messages


### PR DESCRIPTION
## Summary
- ensure pytest can locate package by inserting `src` into `sys.path`

## Testing
- `ruff check --fix`
- `mypy src tests` *(fails: Missing named argument "reply_to_msg_id" for "CanonicalMessage", Function is missing a return type annotation, Argument "stance" to "EnrichmentMessage" has incompatible type, ...)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6c26d55d88326a3209c1aa65021fa