### PR TITLE
fix: include jsonschema dependency and correct readme path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "chatx"
 version = "0.1.0"
 description = "Privacy-focused, local-first CLI tool for forensic chat analysis"
-readme = "docs/index.md"
+readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.11"
 authors = [
@@ -37,6 +37,7 @@ dependencies = [
     "sqlalchemy>=2.0.0",
     "python-dateutil>=2.8.0",
     "pathvalidate>=3.0.0",
+    "jsonschema>=4.0.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dev = [
     "ruff>=0.1.6",
     "pre-commit>=3.5.0",
     "mkdocs-material>=9.0.0",
+    "types-jsonschema>=4.0.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
- point project readme to existing `README.md`
- add `jsonschema` runtime dependency for report validation

## Testing
- `python -m pip install -e .[dev]`
- `ruff check pyproject.toml`
- `mypy src/chatx/utils/run_report.py` *(fails: Library stubs not installed for "jsonschema")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6c6f74ba08326bcaccb2b8f9e004c