### PR TITLE
feat(instagram): add golden ZIP schema test

### DIFF
--- a/src/chatx/utils/json_output.py
+++ b/src/chatx/utils/json_output.py
@@ -2,12 +2,11 @@
 
 import json
 from pathlib import Path
-from typing import List, Optional
 
 from chatx.schemas.message import CanonicalMessage
 
 
-def write_messages_with_validation(messages: List[CanonicalMessage], output_path: Path) -> None:
+def write_messages_with_validation(messages: list[CanonicalMessage], output_path: Path) -> None:
     """Write messages to JSON file with schema validation.
     
     Args:
@@ -23,13 +22,13 @@ def write_messages_with_validation(messages: List[CanonicalMessage], output_path
     # Validate messages, quarantining any invalid ones
     quarantine_dir = output_path.parent / "quarantine"
     quarantine_path = quarantine_dir / "messages_bad.jsonl"
-    messages_data: List[dict] = []
+    messages_data: list[dict] = []
     bad_count = 0
 
     for i, msg in enumerate(messages):
         try:
             # Pydantic validation happens automatically
-            msg_dict = msg.model_dump(mode="json")
+            msg_dict = msg.model_dump(mode="json", by_alias=True)
             messages_data.append(msg_dict)
         except Exception as e:  # pragma: no cover - triggered only by malformed data
             # Lazily create quarantine dir and append the bad record with reason

--- a/tests/fixtures/instagram.py
+++ b/tests/fixtures/instagram.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+from typing import Any
+
+
+def create_instagram_zip_fixture(tmp_dir: Path) -> Path:
+    """Create a synthetic Instagram export ZIP matching expected messages."""
+    zip_path = tmp_dir / "instagram_fixture.zip"
+    thread = "mythread_xx"
+
+    part1 = {
+        "participants": [{"name": "Me"}, {"name": "Friend"}],
+        "messages": [
+            {"sender_name": "Friend", "timestamp_ms": 1_700_000_000_000, "content": "Hi"},
+            {
+                "sender_name": "Me",
+                "timestamp_ms": 1_700_000_100_000,
+                "content": "Hello",
+                "reactions": [
+                    {
+                        "actor": "Friend",
+                        "reaction": "❤️",
+                        "timestamp_ms": 1_700_000_100_100,
+                    }
+                ],
+            },
+        ],
+        "title": thread,
+        "thread_path": f"messages/inbox/{thread}",
+        "thread_type": "Regular",
+        "is_still_participant": True,
+    }
+
+    part2 = {
+        "participants": [{"name": "Me"}, {"name": "Friend"}],
+        "messages": [
+            {
+                "sender_name": "Friend",
+                "timestamp_ms": 1_700_000_200_000,
+                "content": "Photo",
+                "photos": [
+                    {"uri": f"messages/inbox/{thread}/photos/001.jpg"}
+                ],
+            }
+        ],
+        "title": thread,
+        "thread_path": f"messages/inbox/{thread}",
+        "thread_type": "Regular",
+        "is_still_participant": True,
+    }
+
+    with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(f"messages/inbox/{thread}/message_1.json", json.dumps(part1))
+        zf.writestr(f"messages/inbox/{thread}/message_2.json", json.dumps(part2))
+
+    return zip_path
+
+
+def get_expected_instagram_messages() -> list[dict[str, Any]]:
+    """Return expected canonical messages for the synthetic Instagram ZIP."""
+    return [
+        {
+            "msg_id": "ig:mythread_xx:1700000000000:0",
+            "conv_id": "mythread_xx",
+            "platform": "instagram",
+            "timestamp": "2023-11-14T22:13:20+00:00",
+            "sender": "Friend",
+            "sender_id": "Friend",
+            "is_me": False,
+            "text": "Hi",
+            "reply_to_msg_id": None,
+            "reactions": [],
+            "attachments": [],
+        },
+        {
+            "msg_id": "ig:mythread_xx:1700000100000:1",
+            "conv_id": "mythread_xx",
+            "platform": "instagram",
+            "timestamp": "2023-11-14T22:15:00+00:00",
+            "sender": "Me",
+            "sender_id": "Me",
+            "is_me": True,
+            "text": "Hello",
+            "reply_to_msg_id": None,
+            "reactions": [
+                {"from": "Friend", "kind": "❤️", "ts": "2023-11-14T22:15:00.100000Z"}
+            ],
+            "attachments": [],
+        },
+        {
+            "msg_id": "ig:mythread_xx:1700000200000:0",
+            "conv_id": "mythread_xx",
+            "platform": "instagram",
+            "timestamp": "2023-11-14T22:16:40+00:00",
+            "sender": "Friend",
+            "sender_id": "Friend",
+            "is_me": False,
+            "text": "Photo",
+            "reply_to_msg_id": None,
+            "reactions": [],
+            "attachments": [
+                {
+                    "type": "image",
+                    "filename": "messages/inbox/mythread_xx/photos/001.jpg",
+                    "abs_path": None,
+                    "mime_type": None,
+                    "uti": None,
+                    "transfer_name": None,
+                }
+            ],
+        },
+    ]
+

--- a/tests/instagram/test_golden_schema.py
+++ b/tests/instagram/test_golden_schema.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+
+from chatx.instagram.extract import extract_messages_from_zip
+from chatx.utils.json_output import write_messages_with_validation
+from tests.fixtures.instagram import (
+    create_instagram_zip_fixture,
+    get_expected_instagram_messages,
+)
+
+
+def test_instagram_zip_golden_and_schema(tmp_path: Path) -> None:
+    zip_path = create_instagram_zip_fixture(tmp_path)
+    messages = extract_messages_from_zip(
+        zip_path, include_threads_with=["Me"], me_username="Me"
+    )
+    actual = [m.model_dump(exclude={"source_ref", "source_meta"}, mode="json") for m in messages]
+    expected = get_expected_instagram_messages()
+
+    assert len(actual) == len(expected)
+    for msg_dict, exp in zip(actual, expected, strict=False):
+        assert msg_dict["msg_id"] == exp["msg_id"]
+        assert msg_dict["conv_id"] == exp["conv_id"]
+        assert msg_dict["platform"] == exp["platform"]
+        assert msg_dict["timestamp"] == exp["timestamp"]
+        assert msg_dict["sender"] == exp["sender"]
+        assert msg_dict["sender_id"] == exp["sender_id"]
+        assert msg_dict["is_me"] == exp["is_me"]
+        assert msg_dict["text"] == exp["text"]
+        assert msg_dict["reply_to_msg_id"] == exp["reply_to_msg_id"]
+        assert len(msg_dict["reactions"]) == len(exp["reactions"])
+        for r_act, r_exp in zip(msg_dict["reactions"], exp["reactions"], strict=False):
+            assert r_act["from_"] == r_exp["from"]
+            assert r_act["kind"] == r_exp["kind"]
+            assert r_act["ts"] == r_exp["ts"]
+        assert len(msg_dict["attachments"]) == len(exp["attachments"])
+        for a_act, a_exp in zip(msg_dict["attachments"], exp["attachments"], strict=False):
+            assert a_act["type"] == a_exp["type"]
+            assert a_act["filename"] == a_exp["filename"]
+
+    schema = json.load(open(Path("schemas/message.schema.json"), encoding="utf-8"))
+    for msg in messages:
+        jsonschema.validate(msg.model_dump(mode="json", by_alias=True), schema)
+
+    out_file = tmp_path / "instagram_messages.json"
+    write_messages_with_validation(messages, out_file)
+    data = json.load(open(out_file, encoding="utf-8"))
+    assert data["total_count"] == len(expected)
+    for msg in data["messages"]:
+        jsonschema.validate(msg, schema)


### PR DESCRIPTION
## Summary
- add synthetic Instagram export fixture and expected messages
- validate extraction against fixture with JSON schema
- write json output with field aliases for reactions

## Testing
- `ruff check src/chatx/utils/json_output.py tests/fixtures/instagram.py tests/instagram/test_golden_schema.py`
- `mypy src` *(fails: Cannot find implementation or library stub for module named "whisper", etc.)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6d1bf53ac83269249d3ca535af624