### PR TITLE
feat: map dopemux alt-routing to mobile-control session

### DIFF
--- a/docs/reference/commands/dopemux.md
+++ b/docs/reference/commands/dopemux.md
@@ -1,0 +1,29 @@
+# `dopemux` CLI
+
+The `dopemux` executable wires the orchestration CLI to the new session factory. It currently exposes a single `start` command.
+
+## `dopemux start`
+
+Start a Dopemux session. The command now routes the legacy `--alt-routing` flag, and the new `--mobile` alias, to the "happy"
+mobile-control session.
+
+```bash
+$ dopemux start --alt-routing
+```
+
+Outputs a confirmation showing the "happy (mobile-control)" session and the router in use.
+
+### Options
+
+- `--alt-routing`
+  - Legacy flag that now maps directly to the mobile-control session. A warning is printed to highlight the new behaviour.
+- `--mobile`
+  - Preferred alias for the mobile-control session. Safe to use in CI or automation.
+- `--profile-overlay PATH`
+  - Optional JSON document that overlays additional metadata onto the session profile. The loader expects UTF-8 encoded JSON.
+
+### Mobile control router guardrails
+
+The mobile-control session uses the `MobileControlRouter`, which applies an allow-list and confirmation guard to keep automated
+workflows push-safe. Operations such as `open_app`, `home`, and `type_text` require guard confirmation before they dispatch.
+Disallowed actions raise a `RoutingError`.

--- a/docs/reference/commands/index.md
+++ b/docs/reference/commands/index.md
@@ -10,6 +10,9 @@ Topics
 
 Browse the source tree for the full list, or start from notable entries:
 
+- Dopemux orchestration
+  - [dopemux CLI](dopemux.md)
+
 - Task lifecycle
   - `.claude/commands/tm/tm-main.md`
   - `.claude/commands/tm/list/list-tasks.md`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ Issues = "https://github.com/hue/Dopemux-ChatRipperXX/issues"
 
 [project.scripts]
 chatx = "chatx.cli.main:cli"
+dopemux = "chatx.dopemux.cli:app"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/chatx"]

--- a/src/chatx/dopemux/__init__.py
+++ b/src/chatx/dopemux/__init__.py
@@ -1,0 +1,11 @@
+"""Dopemux session orchestration utilities."""
+
+from .session import Session, SessionMode, ProfileOverlay
+from .factory import SessionFactory
+
+__all__ = [
+    "Session",
+    "SessionMode",
+    "ProfileOverlay",
+    "SessionFactory",
+]

--- a/src/chatx/dopemux/cli.py
+++ b/src/chatx/dopemux/cli.py
@@ -1,0 +1,78 @@
+"""Typer-powered CLI for Dopemux session orchestration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+from chatx.dopemux.factory import SessionFactory
+from chatx.dopemux.session import ProfileOverlay, SessionMode
+
+app = typer.Typer(
+    name="dopemux",
+    help="Start and manage Dopemux orchestration sessions.",
+    add_completion=False,
+)
+
+_console = Console()
+
+
+def _resolve_mode(alt_routing: bool, mobile: bool) -> SessionMode:
+    """Determine the session mode from CLI flags."""
+
+    if alt_routing or mobile:
+        return SessionMode.HAPPY
+    return SessionMode.STANDARD
+
+
+@app.command()
+def start(
+    alt_routing: bool = typer.Option(
+        False,
+        "--alt-routing",
+        help="Legacy flag. Starts the mobile-control (happy) session.",
+        rich_help_panel="Routing",
+    ),
+    mobile: bool = typer.Option(
+        False,
+        "--mobile",
+        help="Alias for --alt-routing. Starts the mobile-control (happy) session.",
+        rich_help_panel="Routing",
+    ),
+    profile_overlay: Path | None = typer.Option(
+        None,
+        "--profile-overlay",
+        "-p",
+        help="Path to an optional JSON overlay applied to the session profile.",
+        rich_help_panel="Session",
+    ),
+) -> None:
+    """Start a Dopemux session."""
+
+    mode = _resolve_mode(alt_routing=alt_routing, mobile=mobile)
+    overlay = None
+    if profile_overlay:
+        try:
+            overlay = ProfileOverlay.from_path(profile_overlay)
+        except (FileNotFoundError, ValueError, RuntimeError) as exc:
+            _console.print(f"[bold red]Error:[/bold red] {exc}")
+            raise typer.Exit(1) from exc
+
+    if alt_routing and not mobile:
+        _console.print(
+            "[yellow]`--alt-routing` is legacy and now maps to the mobile-control happy session.[/yellow]",
+        )
+
+    if mobile and alt_routing:
+        _console.print("[cyan]`--mobile` alias acknowledged.[/cyan]")
+
+    factory = SessionFactory()
+    session = factory.create_session(mode=mode, profile_overlay=overlay)
+
+    descriptor = "happy (mobile-control)" if mode is SessionMode.HAPPY else "standard"
+    _console.print(f"[bold green]Started {descriptor} session[/bold green]")
+    _console.print(f"Router: {session.router.__class__.__name__}")
+    if session.profile_overlay:
+        _console.print(f"Profile overlay: {session.profile_overlay.name}")

--- a/src/chatx/dopemux/factory.py
+++ b/src/chatx/dopemux/factory.py
@@ -1,0 +1,59 @@
+"""Session factory wiring CLI inputs to router implementations."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from chatx.dopemux.guards import AlwaysConfirmGuard, ConfirmGuard
+from chatx.dopemux.router.mobile import MobileControlRouter, RoutePolicy
+from chatx.dopemux.router.base import RouterDecision
+from chatx.dopemux.session import ProfileOverlay, Session, SessionMode
+
+
+class DefaultRouter:
+    """Fallback router used by standard sessions."""
+
+    def dispatch(self, action: str, metadata: Mapping[str, Any] | None = None) -> RouterDecision:  # noqa: D401
+        return RouterDecision(action=action, metadata=metadata or {}, confirmed=True)
+
+
+MOBILE_CONTROL_ALLOW_LIST: dict[str, RoutePolicy] = {
+    "tap": RoutePolicy(description="Tap on the screen"),
+    "swipe": RoutePolicy(description="Swipe gesture"),
+    "home": RoutePolicy(description="Return to home screen", requires_confirmation=True),
+    "open_app": RoutePolicy(description="Open an application", requires_confirmation=True),
+    "close_app": RoutePolicy(description="Close an application"),
+    "type_text": RoutePolicy(description="Type text input", requires_confirmation=True),
+}
+
+
+class SessionFactory:
+    """Factory responsible for building sessions for the CLI."""
+
+    def __init__(
+        self,
+        *,
+        confirm_guard: ConfirmGuard | None = None,
+        allow_list: Mapping[str, RoutePolicy] | None = None,
+    ) -> None:
+        self._default_guard = confirm_guard or AlwaysConfirmGuard()
+        self._mobile_allow_list = dict(allow_list or MOBILE_CONTROL_ALLOW_LIST)
+
+    def create_session(
+        self,
+        *,
+        mode: SessionMode,
+        profile_overlay: ProfileOverlay | None = None,
+        confirm_guard: ConfirmGuard | None = None,
+    ) -> Session:
+        """Create a session given the desired mode."""
+
+        if mode is SessionMode.HAPPY:
+            router = MobileControlRouter(
+                allow_list=self._mobile_allow_list,
+                confirm_guard=confirm_guard or self._default_guard,
+            )
+        else:
+            router = DefaultRouter()
+
+        return Session(mode=mode, router=router, profile_overlay=profile_overlay)

--- a/src/chatx/dopemux/guards.py
+++ b/src/chatx/dopemux/guards.py
@@ -1,0 +1,29 @@
+"""Confirmation guard utilities for Dopemux routing."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Mapping, Protocol
+
+
+class ConfirmGuard(Protocol):
+    """Interface used to gate sensitive routing actions."""
+
+    def confirm(self, action: str, metadata: Mapping[str, Any] | None = None) -> bool:
+        """Return ``True`` if the action is permitted."""
+
+
+class AlwaysConfirmGuard:
+    """Guard that approves every action (useful for defaults and tests)."""
+
+    def confirm(self, action: str, metadata: Mapping[str, Any] | None = None) -> bool:  # noqa: D401
+        return True
+
+
+class CallableConfirmGuard:
+    """Wrap a callback inside a :class:`ConfirmGuard` implementation."""
+
+    def __init__(self, callback: Callable[[str, Mapping[str, Any] | None], bool]) -> None:
+        self._callback = callback
+
+    def confirm(self, action: str, metadata: Mapping[str, Any] | None = None) -> bool:
+        return self._callback(action, metadata)

--- a/src/chatx/dopemux/router/__init__.py
+++ b/src/chatx/dopemux/router/__init__.py
@@ -1,0 +1,12 @@
+"""Router implementations for Dopemux sessions."""
+
+from .base import BaseRouter, RouterDecision, RoutingError
+from .mobile import MobileControlRouter, RoutePolicy
+
+__all__ = [
+    "BaseRouter",
+    "RouterDecision",
+    "RoutingError",
+    "MobileControlRouter",
+    "RoutePolicy",
+]

--- a/src/chatx/dopemux/router/base.py
+++ b/src/chatx/dopemux/router/base.py
@@ -1,0 +1,26 @@
+"""Routing primitives for Dopemux sessions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Protocol
+
+
+class RoutingError(RuntimeError):
+    """Raised when a routing request cannot be satisfied."""
+
+
+@dataclass(frozen=True)
+class RouterDecision:
+    """Represents the outcome of dispatching a routing request."""
+
+    action: str
+    metadata: Mapping[str, Any]
+    confirmed: bool
+
+
+class BaseRouter(Protocol):
+    """Interface implemented by Dopemux routers."""
+
+    def dispatch(self, action: str, metadata: Mapping[str, Any] | None = None) -> RouterDecision:
+        """Dispatch an action and return the resulting decision."""

--- a/src/chatx/dopemux/router/mobile.py
+++ b/src/chatx/dopemux/router/mobile.py
@@ -1,0 +1,50 @@
+"""Mobile control router implementation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from chatx.dopemux.guards import ConfirmGuard
+from chatx.dopemux.router.base import RouterDecision, RoutingError
+
+
+@dataclass(frozen=True)
+class RoutePolicy:
+    """Policy associated with a routed mobile action."""
+
+    requires_confirmation: bool = False
+    description: str | None = None
+
+
+class MobileControlRouter:
+    """Router dedicated to mobile-control "happy" sessions."""
+
+    def __init__(
+        self,
+        allow_list: Mapping[str, RoutePolicy],
+        confirm_guard: ConfirmGuard,
+    ) -> None:
+        self._allow_list = dict(allow_list)
+        self._confirm_guard = confirm_guard
+
+    def dispatch(self, action: str, metadata: Mapping[str, Any] | None = None) -> RouterDecision:
+        """Dispatch a mobile control action after applying policy checks."""
+
+        if action not in self._allow_list:
+            raise RoutingError(f"Action '{action}' is not permitted in mobile-control mode")
+
+        policy = self._allow_list[action]
+        confirmed = True
+        if policy.requires_confirmation:
+            confirmed = self._confirm_guard.confirm(action, metadata)
+            if not confirmed:
+                raise RoutingError(f"Action '{action}' was rejected by confirmation guard")
+
+        return RouterDecision(action=action, metadata=metadata or {}, confirmed=confirmed)
+
+    @property
+    def allow_list(self) -> Mapping[str, RoutePolicy]:
+        """Expose the allow-list for inspection/testing purposes."""
+
+        return dict(self._allow_list)

--- a/src/chatx/dopemux/session.py
+++ b/src/chatx/dopemux/session.py
@@ -1,0 +1,59 @@
+"""Session primitives for the Dopemux orchestration layer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping
+import json
+
+from chatx.dopemux.router.base import BaseRouter
+
+
+class SessionMode(str, Enum):
+    """Supported session modes."""
+
+    STANDARD = "standard"
+    HAPPY = "happy"  # Mobile-control session alias
+
+
+@dataclass(frozen=True)
+class ProfileOverlay:
+    """Represents an optional overlay applied to a session profile."""
+
+    name: str
+    data: Mapping[str, Any]
+
+    @classmethod
+    def from_path(cls, path: Path) -> "ProfileOverlay":
+        """Load a profile overlay from a JSON document."""
+
+        if not path.exists():
+            msg = f"Overlay profile not found: {path}"
+            raise FileNotFoundError(msg)
+
+        try:
+            content = path.read_text(encoding="utf-8")
+        except OSError as exc:  # pragma: no cover - propagated
+            raise RuntimeError(f"Unable to read overlay file: {path}") from exc
+
+        try:
+            payload = json.loads(content)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Overlay must be valid JSON: {path}") from exc
+
+        if not isinstance(payload, dict):
+            raise ValueError("Overlay JSON must describe an object")
+
+        name = str(payload.get("name")) if payload.get("name") else path.stem
+        return cls(name=name, data=payload)
+
+
+@dataclass(slots=True)
+class Session:
+    """Container describing an active Dopemux session."""
+
+    mode: SessionMode
+    router: BaseRouter
+    profile_overlay: ProfileOverlay | None = None

--- a/tests/dopemux/test_cli.py
+++ b/tests/dopemux/test_cli.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from chatx.dopemux.cli import app
+
+
+runner = CliRunner()
+
+
+def test_start_standard_session() -> None:
+    result = runner.invoke(app, ["start"])
+
+    assert result.exit_code == 0
+    assert "Started standard session" in result.stdout
+
+
+def test_start_mobile_via_alt_routing() -> None:
+    result = runner.invoke(app, ["start", "--alt-routing"])
+
+    assert result.exit_code == 0
+    assert "mobile-control" in result.stdout
+    assert "legacy" in result.stdout.lower()
+
+
+def test_start_mobile_via_mobile_alias() -> None:
+    result = runner.invoke(app, ["start", "--mobile"])
+
+    assert result.exit_code == 0
+    assert "mobile-control" in result.stdout
+
+
+def test_start_with_profile_overlay(tmp_path) -> None:
+    overlay = tmp_path / "overlay.json"
+    overlay.write_text("{""name"": ""custom""}", encoding="utf-8")
+
+    result = runner.invoke(app, ["start", "--mobile", "--profile-overlay", str(overlay)])
+
+    assert result.exit_code == 0
+    assert "Profile overlay: custom" in result.stdout

--- a/tests/dopemux/test_factory.py
+++ b/tests/dopemux/test_factory.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from chatx.dopemux.factory import SessionFactory
+from chatx.dopemux.router.mobile import MobileControlRouter
+from chatx.dopemux.session import ProfileOverlay, SessionMode
+
+
+def test_factory_creates_happy_session(tmp_path) -> None:
+    overlay_path = tmp_path / "overlay.json"
+    overlay_path.write_text("{""name"": ""mobile""}", encoding="utf-8")
+
+    overlay = ProfileOverlay.from_path(overlay_path)
+    factory = SessionFactory()
+
+    session = factory.create_session(mode=SessionMode.HAPPY, profile_overlay=overlay)
+
+    assert session.mode is SessionMode.HAPPY
+    assert isinstance(session.router, MobileControlRouter)
+    assert session.profile_overlay is overlay
+
+
+def test_factory_creates_standard_session() -> None:
+    factory = SessionFactory()
+
+    session = factory.create_session(mode=SessionMode.STANDARD)
+
+    assert session.mode is SessionMode.STANDARD
+    assert not isinstance(session.router, MobileControlRouter)

--- a/tests/dopemux/test_mobile_router.py
+++ b/tests/dopemux/test_mobile_router.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import pytest
+
+from chatx.dopemux.guards import CallableConfirmGuard
+from chatx.dopemux.router.mobile import MobileControlRouter, RoutePolicy
+from chatx.dopemux.router.base import RoutingError
+
+
+@pytest.fixture()
+def allow_list() -> dict[str, RoutePolicy]:
+    return {
+        "tap": RoutePolicy(),
+        "open_app": RoutePolicy(requires_confirmation=True),
+    }
+
+
+def test_dispatch_allows_listed_action(allow_list: dict[str, RoutePolicy]) -> None:
+    router = MobileControlRouter(allow_list, CallableConfirmGuard(lambda *_: True))
+
+    decision = router.dispatch("tap", {"x": 10, "y": 20})
+
+    assert decision.action == "tap"
+    assert decision.metadata == {"x": 10, "y": 20}
+    assert decision.confirmed is True
+
+
+def test_dispatch_rejects_unlisted_action(allow_list: dict[str, RoutePolicy]) -> None:
+    router = MobileControlRouter(allow_list, CallableConfirmGuard(lambda *_: True))
+
+    with pytest.raises(RoutingError):
+        router.dispatch("swipe")
+
+
+def test_dispatch_respects_confirmation_guard(allow_list: dict[str, RoutePolicy]) -> None:
+    router = MobileControlRouter(allow_list, CallableConfirmGuard(lambda *_: False))
+
+    with pytest.raises(RoutingError):
+        router.dispatch("open_app")


### PR DESCRIPTION
## Summary
- add a dedicated dopemux CLI that wires `start` through the session factory
- introduce a mobile-control router with confirmation guards and allow-listed actions
- support optional profile overlays and document/test the new happy-session behaviour

## Testing
- pytest tests/dopemux *(fails: missing pydantic runtime dependency in test environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69104d8aed688326866e5bb4ce9b85fb)